### PR TITLE
ci: ajoute workflow GitHub Actions de déploiement auto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: SSH & run deploy.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: true
+          command_timeout: 15m
+          script: |
+            ~/deploy.sh


### PR DESCRIPTION
Le workflow se déclenche sur push vers main (et manuellement via workflow_dispatch). Il se connecte en SSH au serveur de prod et lance ~/deploy.sh côté serveur.

Secrets GitHub requis : SSH_HOST, SSH_USER, SSH_PORT, SSH_PRIVATE_KEY.