### PR TITLE
fix(call): pass explicit "audio" to initiateCall in Directory (prod 500)

### DIFF
--- a/FRONTENDV2/src/pages/Directory/Directory.tsx
+++ b/FRONTENDV2/src/pages/Directory/Directory.tsx
@@ -97,7 +97,7 @@ export const Directory: FC = () => {
       firstname: user.firstname,
       lastname: user.lastname,
       picture: "default_profile_picture.png"
-    }]);
+    }], "audio");
   };
 
   return (


### PR DESCRIPTION
## Summary

Hot fix de l'erreur 500 actuellement en prod sur `visioconf.xyz`.

Le merge de PR #37 a introduit un appel à `initiateCall([{...}])` dans `Directory.handleCall` sans le 2e argument, alors que le type de `CallContext.initiateCall` exige `callType: CallType`. L'erreur TypeScript a cassé `npm run build`, le dossier `FRONTENDV2/build/` s'est retrouvé sans `index.html`, et nginx tombait en boucle `try_files` → 500 sur toutes les routes.

## Changements

- `Directory.tsx:100` : passe `"audio"` explicitement à `initiateCall`

## Test plan

- [x] `npm run build` réussit (testé sur le serveur, exit 0)
- [x] `build/index.html` regénéré
- [x] `https://visioconf.xyz/`, `/annuaire`, `/admin` répondent 200
- [ ] Vérifier que cliquer sur "appeler" depuis l'annuaire lance bien un appel audio